### PR TITLE
Support disabled, reference original functions instead of copypasta.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-fast-link-to",
   "dependencies": {
-    "ember": "2.1.0",
+    "ember": "2.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.5",
     "ember-cli-test-loader": "ember-cli-test-loader#0.2.1",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.7",
@@ -12,6 +12,6 @@
     "qunit": "~1.19.0"
   },
   "resolutions": {
-    "ember": "2.1.0"
+    "ember": "2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/github.com:nathanhammond/ember-fast-link-to.git"
+    "url": "git+https://github.com/nathanhammond/ember-fast-link-to.git"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
Copypasta was too dangerous for code drift. This reduces exposure, and adds support for `disabled` as a consequence.
