### PR TITLE
Improve compatibility.

### DIFF
--- a/addon/components/fast-link-to.js
+++ b/addon/components/fast-link-to.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/fast-link-to';
 
-let { assert, get, inject } = Ember;
+let { assert, get, inject, deprecate, ControllerMixin } = Ember;
 let EmberComponent = Ember.Component;
 
 
@@ -193,7 +193,28 @@ let FastLinkComponent = EmberComponent.extend({
 
   _modelsAreLoaded: Ember.LinkComponent.proto()._modelsAreLoaded,
 
-  _getModels: Ember.LinkComponent.proto()._getModels,
+  _getModels(params) {
+    let modelCount = params.length - 1;
+    let models = new Array(modelCount);
+
+    for (let i = 0; i < modelCount; i++) {
+      let value = params[i + 1];
+
+      while (ControllerMixin.detect(value)) {
+        deprecate(
+          'Providing `{{link-to}}` with a param that is wrapped in a controller is deprecated. ' +
+            (this.parentView ? 'Please update `' + this.parentView + '` to use `{{link-to "post" someController.model}}` instead.' : ''),
+          false,
+          { id: 'ember-routing-views.controller-wrapped-param', until: '3.0.0' }
+        );
+        value = value.get('model');
+      }
+
+      models[i] = value;
+    }
+
+    return models;
+  },
 
   /**
     The default href value to use while a fast-link-to is loading.


### PR DESCRIPTION
`_getModels` doesn't show up until Ember 2.2, make this more broadly compatible by including it inline.
